### PR TITLE
remove duplicate comma

### DIFF
--- a/jetcam/usb_camera.py
+++ b/jetcam/usb_camera.py
@@ -30,7 +30,7 @@ class USBCamera(Camera):
         atexit.register(self.cap.release)
                 
     def _gst_str(self):
-        return 'v4l2src device=/dev/video{} ! video/x-raw, width=(int){}, height=(int){}, framerate=(fraction){}/1 ! videoconvert !  video/x-raw, , format=(string)BGR ! appsink'.format(self.capture_device, self.capture_width, self.capture_height, self.capture_fps)
+        return 'v4l2src device=/dev/video{} ! video/x-raw, width=(int){}, height=(int){}, framerate=(fraction){}/1 ! videoconvert !  video/x-raw, format=(string)BGR ! appsink'.format(self.capture_device, self.capture_width, self.capture_height, self.capture_fps)
     
     def _read(self):
         re, image = self.cap.read()


### PR DESCRIPTION
This duplicate comma causes an error on Jetpack 4.3 (OpenCV 4).
error opening bin: could not parse caps "video/x-raw, , format=(string)BGR"
Fix #17 